### PR TITLE
Gallery2: Fix file still exist in SD card when delete from Gallery

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -50,6 +50,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
+    <uses-permission android:name="android.permission.WRITE_MEDIA_STORAGE"/>
     <uses-permission android:name="com.android.gallery3d.permission.GALLERY_PROVIDER" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />


### PR DESCRIPTION
The permission of writing sd card is not effective which cause
this bug happen.

Add write sd card permission.